### PR TITLE
Release Interactive ReaScript (iReaScript) v0.8.45

### DIFF
--- a/Development/cfillion_Interactive ReaScript.lua
+++ b/Development/cfillion_Interactive ReaScript.lua
@@ -1,6 +1,6 @@
 -- @description Interactive ReaScript (iReaScript)
 -- @author cfillion
--- @version 0.8.4
+-- @version 0.8.45
 -- @changelog
 --   Fix autocompletion after an opening parenthesis
 --   Fix display glitch when pasting tab characters


### PR DESCRIPTION
Fix autocompletion after an opening parenthesis
Fix display glitch when pasting tab characters